### PR TITLE
Make assertion and declaration patterns configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ $ npm install --save-dev unassert
 ```
 
 
+API
+---------------------------------------
+
+### var modifiedAst = unassert(ast)
+
+| return type                                                   |
+|:--------------------------------------------------------------|
+| `object` ([ECMAScript AST](https://github.com/estree/estree)) |
+
+Remove assertion calls matched to [patterns](https://github.com/twada/unassert#supported-patterns) from `ast` ([ECMAScript AST](https://github.com/estree/estree)). `ast` is manipulated directly so returned `modifiedAst` will be the same instance of `ast`.
+
+Assertion expressions are removed when they match [default patterns](https://github.com/twada/unassert#supported-patterns). In other words, unassert removes assertion calls that are compatible with Node.js standard assert API (and console.assert).
+
+
 EXAMPLE
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,18 @@ If callee name (for example, `assert.equal`) matches exactly and number of argum
 
 ##### options.requirePatterns
 
-Target patterns for `require` call removal.
+Target patterns for `require` call removal. Must be in form of assignments.
+
+For example,
+
+```js
+{
+    requirePatterns: [
+        'assert = require("assert")'
+    ],
+```
+
+will remove `var assert = require("assert")`, `let assert = require("assert")`, `const assert = require("assert")` and `var assert; assert = require("assert")` as well.
 
 
 ##### options.importPatterns

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ will remove `var assert = require("assert")`, `let assert = require("assert")`, 
 
 Target patterns for import declaration removal.
 
+For example,
+
+```js
+{
+    importPatterns: [
+        'import assert from "assert"',
+        'import * as assert from "assert"',
+        'import assert from "power-assert"',
+        'import * as assert from "power-assert"'
+    ]
+```
 
 ### var options = unassert.defaultOptions()
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,6 @@ Target patterns for assertion removal.
 If callee name (for example, `assert.equal`) matches exactly and number of arguments is satisfied, then the assertion will be removed. Patterns are handled with [escallmatch](https://github.com/twada/escallmatch). Any arguments enclosed in bracket (for example, `[message]`) means optional parameters. Without bracket means mandatory parameters.
 
 
-##### options.assertionPatterns
-
-Target patterns for assertion removal.
-
-If callee name (for example, `assert.equal`) matches exactly and number of arguments is satisfied, then the assertion will be removed. Patterns are handled with [escallmatch](https://github.com/twada/escallmatch). Any arguments enclosed in bracket (for example, `[message]`) means optional parameters. Without bracket means mandatory parameters.
-
-
 ##### options.requirePatterns
 
 Target patterns for `require` call removal.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,81 @@ Remove assertion calls matched to [patterns](https://github.com/twada/unassert#s
 Assertion expressions are removed when they match [default patterns](https://github.com/twada/unassert#supported-patterns). In other words, unassert removes assertion calls that are compatible with Node.js standard assert API (and console.assert).
 
 
+### var visitor = unassert.createVisitor(options)
+
+| return type                                                                       |
+|:----------------------------------------------------------------------------------|
+| `object` (visitor object for [estraverse](https://github.com/estools/estraverse)) |
+
+Create visitor object to be used with `estraverse.replace`. Visitor can be customized by `options`.
+
+
+#### options
+
+Object for configuration options. passed `options` is `Object.assign`ed with default options. If not passed, default options will be used.
+
+
+##### options.assertionPatterns
+
+Target patterns for assertion removal.
+
+If callee name (for example, `assert.equal`) matches exactly and number of arguments is satisfied, then the assertion will be removed. Patterns are handled with [escallmatch](https://github.com/twada/escallmatch). Any arguments enclosed in bracket (for example, `[message]`) means optional parameters. Without bracket means mandatory parameters.
+
+
+##### options.assertionPatterns
+
+Target patterns for assertion removal.
+
+If callee name (for example, `assert.equal`) matches exactly and number of arguments is satisfied, then the assertion will be removed. Patterns are handled with [escallmatch](https://github.com/twada/escallmatch). Any arguments enclosed in bracket (for example, `[message]`) means optional parameters. Without bracket means mandatory parameters.
+
+
+##### options.requirePatterns
+
+Target patterns for `require` call removal.
+
+
+##### options.importPatterns
+
+Target patterns for import declaration removal.
+
+
+### var options = unassert.defaultOptions()
+
+Returns default options object for `createVisitor` function. In other words, returns
+
+```js
+{
+    assertionPatterns: [
+        'assert(value, [message])',
+        'assert.ok(value, [message])',
+        'assert.equal(actual, expected, [message])',
+        'assert.notEqual(actual, expected, [message])',
+        'assert.strictEqual(actual, expected, [message])',
+        'assert.notStrictEqual(actual, expected, [message])',
+        'assert.deepEqual(actual, expected, [message])',
+        'assert.notDeepEqual(actual, expected, [message])',
+        'assert.deepStrictEqual(actual, expected, [message])',
+        'assert.notDeepStrictEqual(actual, expected, [message])',
+        'assert.fail(actual, expected, message, operator)',
+        'assert.throws(block, [error], [message])',
+        'assert.doesNotThrow(block, [message])',
+        'assert.ifError(value)',
+        'console.assert(value, [message])'
+    ],
+    requirePatterns: [
+        'assert = require("assert")',
+        'assert = require("power-assert")'
+    ],
+    importPatterns: [
+        'import assert from "assert"',
+        'import * as assert from "assert"',
+        'import assert from "power-assert"',
+        'import * as assert from "power-assert"'
+    ]
+}
+```
+
+
 EXAMPLE
 ---------------------------------------
 

--- a/index.js
+++ b/index.js
@@ -41,13 +41,10 @@ function isNonBlockChildOfIfStatementOrLoop (currentNode, parentNode, key) {
 
 function compileMatchers (options) {
     var config = objectAssign(defaultOptions(), options);
-    var assertionMatchers = config.assertionPatterns.map(escallmatch);
-    var requireMatchers = config.requirePatterns.map(createRequireMatcher);
-    var importMatchers = config.importPatterns.map(createImportMatcher);
     return {
-        imports: importMatchers,
-        requires: requireMatchers,
-        assertions: assertionMatchers
+        imports: config.importPatterns.map(createImportMatcher),
+        requires: config.requirePatterns.map(createRequireMatcher),
+        assertions: config.assertionPatterns.map(escallmatch)
     };
 }
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ var esutils = require('esutils');
 var objectAssign = require('object-assign');
 var deepEqual = require('deep-equal');
 var defaultOptions = require('./lib/default-options');
+var AstMatcher = require('./lib/ast-matcher');
 
 function matches (node) {
     return function (matcher) {
@@ -65,7 +66,7 @@ function compileMatchers (options) {
         if (body0.type === syntax.VariableDeclaration) {
             declarationMatchers.push(espurify(body0.declarations[0]));
         } else if (body0.type === syntax.ImportDeclaration) {
-            importDeclarationMatchers.push(espurify(body0));
+            importDeclarationMatchers.push(new AstMatcher((body0)));
         }
     });
     return {
@@ -82,7 +83,7 @@ function createVisitorByMatchers (matchers) {
             var espathToRemove;
             switch (currentNode.type) {
             case syntax.ImportDeclaration:
-                if (matchers.imports.some(equivalentTree(currentNode))) {
+                if (matchers.imports.some(matches(currentNode))) {
                     espathToRemove = this.path().join('/');
                     pathToRemove[espathToRemove] = true;
                     this.skip();

--- a/index.js
+++ b/index.js
@@ -13,14 +13,11 @@
 var estraverse = require('estraverse');
 var syntax = estraverse.Syntax;
 var escallmatch = require('escallmatch');
-var espurify = require('espurify');
-var esprima = require('esprima');
 var esutils = require('esutils');
 var objectAssign = require('object-assign');
-var deepEqual = require('deep-equal');
 var defaultOptions = require('./lib/default-options');
-var AstMatcher = require('./lib/ast-matcher');
 var createRequireMatcher = require('./lib/create-require-matcher');
+var createImportMatcher = require('./lib/create-import-matcher');
 
 function matches (node) {
     return function (matcher) {
@@ -46,12 +43,7 @@ function compileMatchers (options) {
     var config = objectAssign(defaultOptions(), options);
     var assertionMatchers = config.assertionPatterns.map(escallmatch);
     var requireMatchers = config.requirePatterns.map(createRequireMatcher);
-    var importMatchers = [];
-    config.importPatterns.forEach(function (dcl) {
-        var ast = esprima.parse(dcl, { sourceType:'module' });
-        var body0 = ast.body[0];
-        importMatchers.push(new AstMatcher((body0)));
-    });
+    var importMatchers = config.importPatterns.map(createImportMatcher);
     return {
         imports: importMatchers,
         requires: requireMatchers,

--- a/index.js
+++ b/index.js
@@ -27,17 +27,11 @@ function matches (node) {
     };
 }
 
-function equivalentTree (node) {
-    return function (example) {
-        return deepEqual(espurify(node), example);
-    };
-}
-
 function assignmentToDeclaredAssert (node) {
-    return function (example) {
+    return function (matcher) {
         return node.operator === '=' &&
-            deepEqual(espurify(node.left), example.id) &&
-            deepEqual(espurify(node.right), example.init);
+            deepEqual(espurify(node.left), matcher.signatureAst.id) &&
+            deepEqual(espurify(node.right), matcher.signatureAst.init);
     };
 }
 
@@ -64,7 +58,7 @@ function compileMatchers (options) {
         var ast = esprima.parse(dcl, { sourceType:'module' });
         var body0 = ast.body[0];
         if (body0.type === syntax.VariableDeclaration) {
-            declarationMatchers.push(espurify(body0.declarations[0]));
+            declarationMatchers.push(new AstMatcher(body0.declarations[0]));
         } else if (body0.type === syntax.ImportDeclaration) {
             importDeclarationMatchers.push(new AstMatcher((body0)));
         }
@@ -90,7 +84,7 @@ function createVisitorByMatchers (matchers) {
                 }
                 break;
             case syntax.VariableDeclarator:
-                if (matchers.requires.some(equivalentTree(currentNode))) {
+                if (matchers.requires.some(matches(currentNode))) {
                     if (parentNode.declarations.length === 1) {
                         // remove parent VariableDeclaration
                         // body/1/declarations/0 -> body/1

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var escallmatch = require('escallmatch');
 var espurify = require('espurify');
 var esprima = require('esprima');
 var esutils = require('esutils');
+var objectAssign = require('object-assign');
 var deepEqual = require('deep-equal');
 var defaultOptions = require('./lib/default-options');
 
@@ -54,7 +55,7 @@ function isNonBlockChildOfIfStatementOrLoop (currentNode, parentNode, key) {
 }
 
 function compileMatchers (options) {
-    var config = Object.assign(defaultOptions(), options);
+    var config = objectAssign(defaultOptions(), options);
     var assertionMatchers = config.assertionPatterns.map(escallmatch);
     var declarationMatchers = [];
     var importDeclarationMatchers = [];

--- a/index.js
+++ b/index.js
@@ -52,20 +52,20 @@ function isNonBlockChildOfIfStatementOrLoop (currentNode, parentNode, key) {
 function compileMatchers (options) {
     var config = objectAssign(defaultOptions(), options);
     var assertionMatchers = config.assertionPatterns.map(escallmatch);
-    var declarationMatchers = [];
-    var importDeclarationMatchers = [];
+    var requireMatchers = [];
+    var importMatchers = [];
     config.declarationPatterns.forEach(function (dcl) {
         var ast = esprima.parse(dcl, { sourceType:'module' });
         var body0 = ast.body[0];
         if (body0.type === syntax.VariableDeclaration) {
-            declarationMatchers.push(new AstMatcher(body0.declarations[0]));
+            requireMatchers.push(new AstMatcher(body0.declarations[0]));
         } else if (body0.type === syntax.ImportDeclaration) {
-            importDeclarationMatchers.push(new AstMatcher((body0)));
+            importMatchers.push(new AstMatcher((body0)));
         }
     });
     return {
-        imports: importDeclarationMatchers,
-        requires: declarationMatchers,
+        imports: importMatchers,
+        requires: requireMatchers,
         assertions: assertionMatchers
     };
 }

--- a/lib/ast-matcher.js
+++ b/lib/ast-matcher.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var deepEqual = require('deep-equal');
+var espurify = require('espurify');
+
+function AstMatcher (signatureAst) {
+    this.signatureAst = espurify(signatureAst);
+    this.rootType = signatureAst.type;
+}
+
+AstMatcher.prototype.test = function (node) {
+    if (!this.isSameRootType(node)) {
+        return false;
+    }
+    return deepEqual(espurify(node), this.signatureAst);
+};
+
+AstMatcher.prototype.isSameRootType = function (node) {
+    return node && node.type === this.rootType;
+};
+
+module.exports = AstMatcher;

--- a/lib/create-import-matcher.js
+++ b/lib/create-import-matcher.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var esprima = require('esprima');
+var espurify = require('espurify');
+var AstMatcher = require('./ast-matcher');
+
+module.exports = function (signatureStr) {
+    var ast = esprima.parse(signatureStr, { sourceType:'module' });
+    var decl = ast.body[0];
+    return new AstMatcher(espurify(decl));
+};

--- a/lib/create-require-matcher.js
+++ b/lib/create-require-matcher.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var esprima = require('esprima');
+var espurify = require('espurify');
+var RequireMatcher = require('./require-matcher');
+
+function extractAssignmentExpressionFrom (tree) {
+    var statement = (tree.type === 'Program') ? tree.body[0] : tree;
+    var expression;
+    if (statement.type !== 'ExpressionStatement') {
+        throw new Error('Argument should be in the form of expression');
+    }
+    expression = statement.expression;
+    if (expression.type !== 'AssignmentExpression') {
+        throw new Error('Argument should be in the form of assignment');
+    }
+    return expression;
+}
+
+module.exports = function (signatureStr) {
+    var signatureAst = esprima.parse(signatureStr, { sourceType:'module' });
+    var assignment = extractAssignmentExpressionFrom(signatureAst);
+    return new RequireMatcher(espurify(assignment));
+};

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -19,13 +19,15 @@ module.exports = function defaultOptions () {
             'assert.ifError(value)',
             'console.assert(value, [message])'
         ],
-        declarationPatterns: [
+        requirePatterns: [
+            'assert = require("assert")',
+            'assert = require("power-assert")'
+        ],
+        importPatterns: [
             'import assert from "assert"',
             'import * as assert from "assert"',
-            'var assert = require("assert")',
             'import assert from "power-assert"',
-            'import * as assert from "power-assert"',
-            'var assert = require("power-assert")'
+            'import * as assert from "power-assert"'
         ]
     };
 };

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = function defaultOptions () {
+    return {
+        assertionPatterns: [
+            'assert(value, [message])',
+            'assert.ok(value, [message])',
+            'assert.equal(actual, expected, [message])',
+            'assert.notEqual(actual, expected, [message])',
+            'assert.strictEqual(actual, expected, [message])',
+            'assert.notStrictEqual(actual, expected, [message])',
+            'assert.deepEqual(actual, expected, [message])',
+            'assert.notDeepEqual(actual, expected, [message])',
+            'assert.deepStrictEqual(actual, expected, [message])',
+            'assert.notDeepStrictEqual(actual, expected, [message])',
+            'assert.fail(actual, expected, message, operator)',
+            'assert.throws(block, [error], [message])',
+            'assert.doesNotThrow(block, [message])',
+            'assert.ifError(value)',
+            'console.assert(value, [message])'
+        ],
+        declarationPatterns: [
+            'import assert from "assert"',
+            'import * as assert from "assert"',
+            'var assert = require("assert")',
+            'import assert from "power-assert"',
+            'import * as assert from "power-assert"',
+            'var assert = require("power-assert")'
+        ]
+    };
+};

--- a/lib/require-matcher.js
+++ b/lib/require-matcher.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var deepEqual = require('deep-equal');
+var espurify = require('espurify');
+
+function RequireMatcher (signatureAst) {
+    this.signatureAst = signatureAst;
+}
+
+RequireMatcher.prototype.test = function (node) {
+    if (!isAcceptableNode(node)) {
+        return false;
+    }
+    var id, init;
+    switch (node.type) {
+    case 'VariableDeclarator':
+        id = node.id;
+        init = node.init;
+        break;
+    case 'AssignmentExpression':
+        if (node.operator !== '=') {
+            return false;
+        }
+        id = node.left;
+        init = node.right;
+        break;
+    }
+    return id && init &&
+        deepEqual(espurify(id), this.signatureAst.left) &&
+        deepEqual(espurify(init), this.signatureAst.right);
+};
+
+function isAcceptableNode (node) {
+    return node && (node.type === 'VariableDeclarator' || node.type === 'AssignmentExpression');
+}
+
+module.exports = RequireMatcher;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/twada/unassert/issues",
   "dependencies": {
     "deep-equal": "^1.0.0",
-    "escallmatch": "^1.4.1",
+    "escallmatch": "^1.5.0",
     "esprima": "^2.5.0",
     "espurify": "^1.3.0",
     "estraverse": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "esprima": "^2.5.0",
     "espurify": "^1.3.0",
     "estraverse": "^4.1.0",
-    "esutils": "^2.0.2"
+    "esutils": "^2.0.2",
+    "object-assign": "^4.1.0"
   },
   "devDependencies": {
     "escodegen": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "README.md",
     "CHANGELOG.md",
     "index.js",
+    "lib",
     "package.json"
   ],
   "homepage": "https://github.com/twada/unassert",

--- a/test/fixtures/customization_httpassert/expected.js
+++ b/test/fixtures/customization_httpassert/expected.js
@@ -1,0 +1,4 @@
+'use strict';
+try {
+} catch (err) {
+}

--- a/test/fixtures/customization_httpassert/fixture.js
+++ b/test/fixtures/customization_httpassert/fixture.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var assert = require('http-assert');
+var ok = require('assert');
+
+try {
+    assert(username == 'foo', 401, 'authentication failed');
+} catch (err) {
+    ok(err.status == 401);
+    ok(err.message == 'authentication failed');
+    ok(err.expose);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -63,9 +63,9 @@ describe('with options', function () {
             'ok(actual, [message])',
             'assert(value, status, [msg], [opts])'
         ],
-        declarationPatterns: [
-            'var assert = require("http-assert")',
-            'var ok = require("assert")'
+        requirePatterns: [
+            'assert = require("http-assert")',
+            'ok = require("assert")'
         ]
     });
 
@@ -89,15 +89,17 @@ describe('with options', function () {
             'assert.ifError(value)',
             'console.assert(value, [message])'
         ],
-        declarationPatterns: [
-            'var assert = require("http-assert")',
-            'var ok = require("assert")',
+        requirePatterns: [
+            'assert = require("http-assert")',
+            'ok = require("assert")',
+            'assert = require("assert")',
+            'assert = require("power-assert")'
+        ],
+        importPatterns: [
             'import assert from "assert"',
             'import * as assert from "assert"',
-            'var assert = require("assert")',
             'import assert from "power-assert"',
-            'import * as assert from "power-assert"',
-            'var assert = require("power-assert")'
+            'import * as assert from "power-assert"'
         ]
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,12 @@ describe('default behavior', function () {
             var actual = escodegen.generate(modifiedAst);
             assert.equal(actual + '\n', expected);
         });
+        it('unassert.createVisitor ' + fixtureName, function () {
+            var ast = esprima.parse(fs.readFileSync(fixtureFilepath),  { sourceType: 'module' });
+            var modifiedAst = estraverse.replace(ast, unassert.createVisitor());
+            var actual = escodegen.generate(modifiedAst);
+            assert.equal(actual + '\n', expected);
+        });
     }
 
     testTransform('func');

--- a/test/test.js
+++ b/test/test.js
@@ -7,21 +7,23 @@ var path = require('path');
 var fs = require('fs');
 var esprima = require('esprima');
 var escodegen = require('escodegen');
+var estraverse = require('estraverse');
 
-function testTransform (fixtureName, extraOptions) {
-    it(fixtureName, function () {
+
+describe('default behavior', function () {
+    function testTransform (fixtureName) {
         var fixtureFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
         var expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected.js');
-        var ast = esprima.parse(fs.readFileSync(fixtureFilepath),  { sourceType: 'module' });
-        // console.log(JSON.stringify(ast, null, 2));
-        var modifiedAst = unassert(ast);
-        var actual = escodegen.generate(modifiedAst);
         var expected = fs.readFileSync(expectedFilepath).toString();
-        assert.equal(actual + '\n', expected);
-    });
-}
 
-describe('unassert', function () {
+        it('unassert ' + fixtureName, function () {
+            var ast = esprima.parse(fs.readFileSync(fixtureFilepath),  { sourceType: 'module' });
+            var modifiedAst = unassert(ast);
+            var actual = escodegen.generate(modifiedAst);
+            assert.equal(actual + '\n', expected);
+        });
+    }
+
     testTransform('func');
     testTransform('commonjs');
     testTransform('commonjs_singlevar');
@@ -33,4 +35,63 @@ describe('unassert', function () {
     testTransform('es6module_namespece');
     testTransform('not_an_expression_statement');
     testTransform('non_block_statement');
+});
+
+
+describe('with options', function () {
+    function testWithCustomization (fixtureName, extraOptions) {
+        var fixtureFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
+        var expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected.js');
+        var expected = fs.readFileSync(expectedFilepath).toString();
+
+        it('unassert.createVisitor ' + fixtureName, function () {
+            var ast = esprima.parse(fs.readFileSync(fixtureFilepath),  { sourceType: 'module' });
+            var modifiedAst = estraverse.replace(ast, unassert.createVisitor(extraOptions));
+            var actual = escodegen.generate(modifiedAst);
+            assert.equal(actual + '\n', expected);
+        });
+    }
+
+    testWithCustomization('customization_httpassert', {
+        assertionPatterns: [
+            'ok(actual, [message])',
+            'assert(value, status, [msg], [opts])'
+        ],
+        declarationPatterns: [
+            'var assert = require("http-assert")',
+            'var ok = require("assert")'
+        ]
+    });
+
+    testWithCustomization('func', {
+        assertionPatterns: [
+            'ok(actual, [message])',
+            'assert(value, status, [msg], [opts])',
+            'assert(value, [message])',
+            'assert.ok(value, [message])',
+            'assert.equal(actual, expected, [message])',
+            'assert.notEqual(actual, expected, [message])',
+            'assert.strictEqual(actual, expected, [message])',
+            'assert.notStrictEqual(actual, expected, [message])',
+            'assert.deepEqual(actual, expected, [message])',
+            'assert.notDeepEqual(actual, expected, [message])',
+            'assert.deepStrictEqual(actual, expected, [message])',
+            'assert.notDeepStrictEqual(actual, expected, [message])',
+            'assert.fail(actual, expected, message, operator)',
+            'assert.throws(block, [error], [message])',
+            'assert.doesNotThrow(block, [message])',
+            'assert.ifError(value)',
+            'console.assert(value, [message])'
+        ],
+        declarationPatterns: [
+            'var assert = require("http-assert")',
+            'var ok = require("assert")',
+            'import assert from "assert"',
+            'import * as assert from "assert"',
+            'var assert = require("assert")',
+            'import assert from "power-assert"',
+            'import * as assert from "power-assert"',
+            'var assert = require("power-assert")'
+        ]
+    });
 });


### PR DESCRIPTION
Expose `createVisitor` to make assertion and declaration patterns configurable.

### var visitor = unassert.createVisitor(options)

| return type                                                                       |
|:----------------------------------------------------------------------------------|
| `object` (visitor object for [estraverse](https://github.com/estools/estraverse)) |

Create visitor object to be used with `estraverse.replace`. Visitor can be customized by `options`.


#### options

Object for configuration options. passed `options` is `Object.assign`ed with default options. If not passed, default options will be used.


##### options.assertionPatterns

Target patterns for assertion removal.

If callee name (for example, `assert.equal`) matches exactly and number of arguments is satisfied, then the assertion will be removed. Patterns are handled with [escallmatch](https://github.com/twada/escallmatch). Any arguments enclosed in bracket (for example, `[message]`) means optional parameters. Without bracket means mandatory parameters.


##### options.requirePatterns

Target patterns for `require` call removal. Must be in form of assignments.

For example,

```js
{
    requirePatterns: [
        'assert = require("assert")'
    ],
```

will remove `var assert = require("assert")`, `let assert = require("assert")`, `const assert = require("assert")` and `var assert; assert = require("assert")` as well.


##### options.importPatterns

Target patterns for import declaration removal.

For example,

```js
{
    importPatterns: [
        'import assert from "assert"',
        'import * as assert from "assert"',
        'import assert from "power-assert"',
        'import * as assert from "power-assert"'
    ]
```
