### PR TITLE
Dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "bugs": "https://github.com/unassert-js/unassert/issues",
   "dependencies": {
     "acorn": "^4.0.0",
-    "call-matcher": "^1.0.1",
+    "call-matcher": "^2.0.0",
     "deep-equal": "^1.0.0",
-    "espurify": "^1.3.0",
+    "espurify": "^2.0.1",
     "estraverse": "^4.1.0",
     "esutils": "^2.0.2",
     "object-assign": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bugs": "https://github.com/unassert-js/unassert/issues",
   "dependencies": {
-    "acorn": "^4.0.0",
+    "acorn": "^6.1.1",
     "call-matcher": "^2.0.0",
     "deep-equal": "^1.0.0",
     "espurify": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bugs": "https://github.com/unassert-js/unassert/issues",
   "dependencies": {
-    "acorn": "^6.1.1",
+    "acorn": "^7.0.0",
     "call-matcher": "^2.0.0",
     "deep-equal": "^1.0.0",
     "espurify": "^2.0.1",


### PR DESCRIPTION
Updates to more recent call-matcher and espurify versions, which don't depend on the big core-js library.

Also updates acorn to the most recent version, which still works on all the same Node.js versions as previously.