### PR TITLE
feat: replace default exported `unassert` with named exported `unassertAst`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Target variable names for assertion call removal.
 
 For example,
 
-```js
+```javascript
 {
   variables: [
     'assert'
@@ -136,10 +136,11 @@ Target module names for `require` and `import` call removal.
 
 For example,
 
-```js
+```javascript
 {
   modules: [
-    'assert'
+    'assert',
+    'node:assert'
   ]
 ```
 
@@ -164,6 +165,32 @@ and assignments.
 * `assert = require("node:assert").strict`
 
 
+### const visitor = createVisitor(options)
+
+| return type                                                                       |
+|:----------------------------------------------------------------------------------|
+| `object` (visitor object for [estraverse](https://github.com/estools/estraverse)) |
+
+Create visitor object to be used with `estraverse.replace`. Visitor can be customized by `options`.
+
+
+### const options = defaultOptions()
+
+Returns default options object for `unassertAst` and `createVisitor` function. In other words, returns
+
+```javascript
+{
+  variables: [
+    'assert'
+  ],
+  modules: [
+    'assert',
+    'power-assert',
+    'node:assert'
+  ]
+}
+```
+
 CUSTOMIZATION
 ---------------------------------------
 
@@ -171,7 +198,7 @@ You can customize options such as assertion variable names and module names.
 
 options:
 
-```
+```javascript
 {
   variables: [
     'assert',
@@ -220,32 +247,6 @@ output:
 ```javascript
 function add(a, b) {
   return a + b;
-}
-```
-
-### const visitor = createVisitor(options)
-
-| return type                                                                       |
-|:----------------------------------------------------------------------------------|
-| `object` (visitor object for [estraverse](https://github.com/estools/estraverse)) |
-
-Create visitor object to be used with `estraverse.replace`. Visitor can be customized by `options`.
-
-
-### const options = defaultOptions()
-
-Returns default options object for `unassertAst` and `createVisitor` function. In other words, returns
-
-```js
-{
-  variables: [
-    'assert'
-  ],
-  modules: [
-    'assert',
-    'power-assert',
-    'node:assert'
-  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See: "[unassert - encourage reliable programming by writing assertions in produc
 - [unassert-cli](https://github.com/unassert-js/unassert-cli): CLI for unassert
 - [rollup-plugin-unassert](https://gitlab.com/IvanSanchez/rollup-plugin-unassert): RollupJS plugin for unassert
 
+
 INSTALL
 ---------------------------------------
 
@@ -27,26 +28,64 @@ $ npm install --save-dev unassert
 ```
 
 
+EXAMPLE
+---------------------------------------
+
+For given `math.js` below,
+
+```javascript
+const assert = require('node:assert');
+
+function add (a, b) {
+  assert(typeof a === 'number');
+  console.assert(!isNaN(a));
+  assert.equal(typeof b, 'number');
+  assert.ok(!isNaN(b));
+  return a + b;
+}
+```
+
+Apply `unassertAst` then generate modified code to console.
+
+```javascript
+const { unassertAst } = require('unassert');
+const acorn = require('acorn');
+const escodegen = require('escodegen');
+const fs = require('node:fs');
+const path = require('node:path');
+const filepath = path.join(__dirname, 'math.js');
+
+const ast = acorn.parse(fs.readFileSync(filepath), { ecmaVersion: '2022' });
+const modifiedAst = unassertAst(ast);
+
+console.log(escodegen.generate(modifiedAst));
+```
+
+Then you will see assert calls disappear.
+
+```javascript
+function add(a, b) {
+  return a + b;
+}
+```
+
+
 API
 ---------------------------------------
 
-### const modifiedAst = unassert(ast)
+unassert package exports three functions. `unassertAst` is the main function. `createVisitor` and `defaultOptions` are for customization.
+
+```javascript
+const { unassertAst, createVisitor, defaultOptions } = require('unassert')
+```
+
+### const modifiedAst = unassertAst(ast, options)
 
 | return type                                                   |
 |:--------------------------------------------------------------|
 | `object` ([ECMAScript AST](https://github.com/estree/estree)) |
 
-Remove assertion calls from `ast` ([ECMAScript AST](https://github.com/estree/estree)). `ast` is manipulated directly so returned `modifiedAst` will be the same instance of `ast`.
-
-
-### const visitor = unassert.createVisitor(options)
-
-| return type                                                                       |
-|:----------------------------------------------------------------------------------|
-| `object` (visitor object for [estraverse](https://github.com/estools/estraverse)) |
-
-Create visitor object to be used with `estraverse.replace`. Visitor can be customized by `options`.
-
+Remove assertion calls from `ast` ([ECMAScript AST](https://github.com/estree/estree)). Default behaviour can be customized by `options`. `ast` is manipulated directly so returned `modifiedAst` will be the same instance of `ast`.
 
 #### options
 
@@ -125,9 +164,77 @@ and assignments.
 * `assert = require("node:assert").strict`
 
 
-### const options = unassert.defaultOptions()
+CUSTOMIZATION
+---------------------------------------
 
-Returns default options object for `createVisitor` function. In other words, returns
+You can customize options such as assertion variable names and module names.
+
+options:
+
+```
+{
+  variables: [
+    'assert',
+    'invariant',
+    'nassert',
+    'uassert'
+  ],
+  modules: [
+    'assert',
+    'node:assert',
+    'invariant',
+    'nanoassert',
+    'uvu/assert'
+  ]
+}
+```
+
+input:
+
+```javascript
+import {strict as assert} from 'node:assert';
+import invariant from 'invariant';
+import nassert from 'nanoassert';
+import * as uassert from 'uvu/assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+
+    nassert(!isNaN(a));
+
+    uassert.is(Math.sqrt(4), 2);
+    uassert.is(Math.sqrt(144), 12);
+    uassert.is(Math.sqrt(2), Math.SQRT2);
+
+    invariant(someTruthyVal, 'This will not throw');
+    invariant(someFalseyVal, 'This will throw an error with this message');
+
+    return a + b;
+}
+```
+
+output:
+
+```javascript
+function add(a, b) {
+  return a + b;
+}
+```
+
+### const visitor = createVisitor(options)
+
+| return type                                                                       |
+|:----------------------------------------------------------------------------------|
+| `object` (visitor object for [estraverse](https://github.com/estools/estraverse)) |
+
+Create visitor object to be used with `estraverse.replace`. Visitor can be customized by `options`.
+
+
+### const options = defaultOptions()
+
+Returns default options object for `unassertAst` and `createVisitor` function. In other words, returns
 
 ```js
 {
@@ -141,51 +248,6 @@ Returns default options object for `createVisitor` function. In other words, ret
   ]
 }
 ```
-
-
-EXAMPLE
----------------------------------------
-
-For given `math.js` below,
-
-```javascript
-const assert = require('assert');
-
-function add (a, b) {
-  assert(typeof a === 'number');
-  console.assert(!isNaN(a));
-  assert.equal(typeof b, 'number');
-  assert.ok(!isNaN(b));
-  return a + b;
-}
-```
-
-Apply `unassert` then generate modified code to console.
-
-```javascript
-const acorn = require('acorn');
-const escodegen = require('escodegen');
-const unassert = require('unassert');
-const fs = require('fs');
-const path = require('path');
-const filepath = path.join(__dirname, 'math.js');
-
-const ast = acorn.parse(fs.readFileSync(filepath));
-const modifiedAst = unassert(ast);
-
-console.log(escodegen.generate(modifiedAst));
-```
-
-Then you will see assert calls disappear.
-
-```javascript
-function add(a, b) {
-  return a + b;
-}
-```
-
-Note: unassert supports removal of [power-assert](https://github.com/power-assert-js/power-assert) declarations (`var assert = require('power-assert');`) too.
-
 
 OUR SUPPORT POLICY
 ---------------------------------------

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ For example,
 {
   modules: [
     'assert',
+    'power-assert',
     'node:assert'
   ]
 ```
@@ -147,21 +148,28 @@ For example,
 will remove assert variable declarations such as,
 
 * `const assert = require("assert")`
+* `const assert = require("power-assert")`
 * `const assert = require("node:assert")`
 * `const assert = require("assert").strict`
+* `const assert = require("power-assert").strict`
 * `const assert = require("node:assert").strict`
 * `import assert from "assert"`
+* `import assert from "power-assert"`
 * `import assert from "node:assert"`
 * `import * as assert from "assert"`
+* `import * as assert from "power-assert"`
 * `import * as assert from "node:assert"`
 * `import {strict as assert} from "assert"`
+* `import {strict as assert} from "power-assert"`
 * `import {strict as assert} from "node:assert"`
 
 and assignments.
 
 * `assert = require("assert")`
+* `assert = require("power-assert")`
 * `assert = require("node:assert")`
 * `assert = require("assert").strict`
+* `assert = require("power-assert").strict`
 * `assert = require("node:assert").strict`
 
 
@@ -249,6 +257,9 @@ function add(a, b) {
   return a + b;
 }
 ```
+
+Note: unassert supports removal of [power-assert](https://github.com/power-assert-js/power-assert) declarations (`require('power-assert');`) too.
+
 
 OUR SUPPORT POLICY
 ---------------------------------------

--- a/index.js
+++ b/index.js
@@ -10,9 +10,8 @@
  */
 'use strict';
 
-const estraverse = require('estraverse');
-const syntax = estraverse.Syntax;
-const esutils = require('esutils');
+const { replace, Syntax: syntax } = require('estraverse');
+const { ast: esutilsAst } = require('esutils');
 
 function defaultOptions () {
   return {
@@ -32,7 +31,7 @@ function isBodyOfIfStatement (parentNode, key) {
 }
 
 function isBodyOfIterationStatement (parentNode, key) {
-  return esutils.ast.isIterationStatement(parentNode) && key === 'body';
+  return esutilsAst.isIterationStatement(parentNode) && key === 'body';
 }
 
 function isNonBlockChildOfIfStatementOrLoop (currentNode, parentNode, key) {
@@ -227,10 +226,12 @@ function createVisitor (options) {
   };
 }
 
-function unassert (ast) {
-  return estraverse.replace(ast, createVisitor());
+function unassertAst (ast, options) {
+  return replace(ast, createVisitor(options));
 }
 
-unassert.defaultOptions = defaultOptions;
-unassert.createVisitor = createVisitor;
-module.exports = unassert;
+module.exports = {
+  unassertAst,
+  defaultOptions,
+  createVisitor
+};

--- a/test/fixtures/customization_various_modules/expected.js
+++ b/test/fixtures/customization_various_modules/expected.js
@@ -1,0 +1,3 @@
+function add(a, b) {
+    return a + b;
+}

--- a/test/fixtures/customization_various_modules/fixture.js
+++ b/test/fixtures/customization_various_modules/fixture.js
@@ -1,0 +1,21 @@
+import {strict as assert} from 'node:assert';
+import invariant from 'invariant';
+import nassert from 'nanoassert';
+import * as uassert from 'uvu/assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+
+    nassert(!isNaN(a));
+
+    uassert.is(Math.sqrt(4), 2);
+    uassert.is(Math.sqrt(144), 12);
+    uassert.is(Math.sqrt(2), Math.SQRT2);
+
+    invariant(someTruthyVal, 'This will not throw');
+    invariant(someFalseyVal, 'This will throw an error with this message');
+
+    return a + b;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -47,20 +47,20 @@ describe('default behavior (with default options)', function () {
 });
 
 describe('with customized options', function () {
-  function testWithCustomization (fixtureName, extraOptions) {
+  function testWithCustomization (fixtureName, options) {
     const fixtureFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
     const expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected.js');
     const expected = fs.readFileSync(expectedFilepath).toString();
 
     it('unassertAst ' + fixtureName, function () {
       const ast = parse(fixtureFilepath);
-      const modifiedAst = unassertAst(ast, extraOptions);
+      const modifiedAst = unassertAst(ast, options);
       const actual = escodegen.generate(modifiedAst);
       assert.equal(actual + '\n', expected);
     });
     it('createVisitor ' + fixtureName, function () {
       const ast = parse(fixtureFilepath);
-      const modifiedAst = estraverse.replace(ast, createVisitor(extraOptions));
+      const modifiedAst = estraverse.replace(ast, createVisitor(options));
       const actual = escodegen.generate(modifiedAst);
       assert.equal(actual + '\n', expected);
     });
@@ -74,6 +74,22 @@ describe('with customized options', function () {
     modules: [
       'assert',
       'http-assert'
+    ]
+  });
+
+  testWithCustomization('customization_various_modules', {
+    variables: [
+      'assert',
+      'invariant',
+      'nassert',
+      'uassert'
+    ],
+    modules: [
+      'assert',
+      'node:assert',
+      'invariant',
+      'nanoassert',
+      'uvu/assert'
     ]
   });
 


### PR DESCRIPTION
feat: replace default exported unassert with named exported `unassertAst`

BREAKING CHANGE:

`unassert` function is removed in favor of named exports aiming ESM era.
Please use `unassert.unassertAst` instead.