### PR TITLE
Migrate codebase to ESM and provide CJS/ESM dual package

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,36 @@ function add (a, b) {
 
 Apply `unassertAst` then generate modified code to console.
 
+via CJS code
 ```javascript
 const { unassertAst } = require('unassert');
-const acorn = require('acorn');
-const escodegen = require('escodegen');
-const fs = require('node:fs');
-const path = require('node:path');
-const filepath = path.join(__dirname, 'math.js');
+const { parse } = require('acorn');
+const { generate } = require('escodegen');
+const { readFileSync } = require('node:fs');
+const { join, dirname } = require('node:path');
 
-const ast = acorn.parse(fs.readFileSync(filepath), { ecmaVersion: '2022' });
+const filepath = join(__dirname, 'math.js');
+const ast = parse(readFileSync(filepath), { ecmaVersion: '2022' });
 const modifiedAst = unassertAst(ast);
 
-console.log(escodegen.generate(modifiedAst));
+console.log(generate(modifiedAst));
+```
+
+or via ESM code
+```javascript
+import { unassertAst } from 'unassert';
+import { parse } from 'acorn';
+import { generate } from 'escodegen';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const filepath = join(__dirname, 'math.js');
+const ast = parse(readFileSync(filepath), { ecmaVersion: '2022' });
+const modifiedAst = unassertAst(ast);
+
+console.log(generate(modifiedAst));
 ```
 
 Then you will see assert calls disappear.
@@ -77,6 +95,10 @@ unassert package exports three functions. `unassertAst` is the main function. `c
 
 ```javascript
 const { unassertAst, createVisitor, defaultOptions } = require('unassert')
+```
+
+```javascript
+import { unassertAst, createVisitor, defaultOptions } from 'unassert'
 ```
 
 ### const modifiedAst = unassertAst(ast, options)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "acorn": "^8.0.0",
         "escodegen": "^2.0.0",
         "mocha": "^10.0.0",
+        "rimraf": "^3.0.2",
+        "rollup": "^2.77.0",
         "semistandard": "^16.0.0",
         "snazzy": "^9.0.0"
       }
@@ -2873,6 +2875,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
+      "integrity": "sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5618,6 +5635,15 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
+      "integrity": "sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   "scripts": {
     "preversion": "npm run build && npm test",
     "build": "rimraf dist && rollup -c",
-    "lint": "semistandard --verbose index.js test/test.js | snazzy",
-    "fmt": "semistandard --fix index.js test/test.js",
+    "lint": "semistandard --verbose src/*.mjs test/*.mjs | snazzy",
+    "fmt": "semistandard --fix src/*.mjs test/*.mjs",
     "test": "npm run lint && mocha test"
   },
   "semistandard": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "acorn": "^8.0.0",
     "escodegen": "^2.0.0",
     "mocha": "^10.0.0",
+    "rimraf": "^3.0.2",
+    "rollup": "^2.77.0",
     "semistandard": "^16.0.0",
     "snazzy": "^9.0.0"
   },
@@ -46,7 +48,8 @@
     "url": "https://github.com/unassert-js/unassert.git"
   },
   "scripts": {
-    "preversion": "npm test",
+    "preversion": "npm run build && npm test",
+    "build": "rimraf dist && rollup -c",
     "lint": "semistandard --verbose index.js test/test.js | snazzy",
     "fmt": "semistandard --fix index.js test/test.js",
     "test": "npm run lint && mocha test"

--- a/package.json
+++ b/package.json
@@ -31,9 +31,14 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE",
-    "index.js",
-    "package.json"
+    "src",
+    "dist"
   ],
+  "main": "./dist/index.cjs",
+  "exports": {
+    "import": "./src/index.mjs",
+    "require": "./dist/index.cjs"
+  },
   "homepage": "https://github.com/unassert-js/unassert",
   "keywords": [
     "DbC",
@@ -42,7 +47,6 @@
     "assertion"
   ],
   "license": "MIT",
-  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/unassert-js/unassert.git"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,23 @@
+import { promises as fs } from 'fs';
+
+const srcDir = 'src';
+const destDir = 'dist';
+
+const srcFiles = await fs.readdir(new URL(`./${srcDir}`, import.meta.url));
+
+export default {
+  input: srcFiles.filter((file) => file.endsWith('.mjs')).map((x) => `${srcDir}/${x}`),
+  output: {
+    dir: destDir,
+    format: 'cjs',
+    entryFileNames: '[name].cjs',
+    // create a module for each module in the input, instead of trying to chunk them together.
+    preserveModules: true,
+    // do not add `Object.defineProperty(exports, '__esModule', { value: true })`
+    esModule: false,
+    // use const instead of var when creating statements
+    preferConst: true,
+    // do not add _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+    interop: false,
+  }
+};

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -8,10 +8,8 @@
  * Licensed under the MIT license.
  *   https://github.com/unassert-js/unassert/blob/master/LICENSE
  */
-'use strict';
-
-const { replace, Syntax: syntax } = require('estraverse');
-const { ast: esutilsAst } = require('esutils');
+import { replace, Syntax as syntax } from 'estraverse';
+import { ast as esutilsAst } from 'esutils';
 
 function defaultOptions () {
   return {
@@ -229,7 +227,7 @@ function unassertAst (ast, options) {
   return replace(ast, createVisitor(options));
 }
 
-module.exports = {
+export {
   unassertAst,
   defaultOptions,
   createVisitor

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1,34 +1,34 @@
-'use strict';
+import { unassertAst, createVisitor } from '../src/index.mjs';
+import { strict as assert } from 'assert';
+import { resolve, dirname } from 'path';
+import { readFileSync } from 'fs';
+import { parse } from 'acorn';
+import { generate } from 'escodegen';
+import { replace } from 'estraverse';
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
-delete require.cache[require.resolve('../index.js')];
-const { unassertAst, createVisitor } = require('../index.js');
-const assert = require('assert');
-const path = require('path');
-const fs = require('fs');
-const acorn = require('acorn');
-const escodegen = require('escodegen');
-const estraverse = require('estraverse');
-
-function parse (filepath) {
-  return acorn.parse(fs.readFileSync(filepath), { sourceType: 'module', ecmaVersion: '2022' });
+function parseFixture (filepath) {
+  return parse(readFileSync(filepath), { sourceType: 'module', ecmaVersion: '2022' });
 }
 
 describe('default behavior (with default options)', function () {
   function testTransform (fixtureName) {
-    const fixtureFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
-    const expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected.js');
-    const expected = fs.readFileSync(expectedFilepath).toString();
+    const fixtureFilepath = resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
+    const expectedFilepath = resolve(__dirname, 'fixtures', fixtureName, 'expected.js');
+    const expected = readFileSync(expectedFilepath).toString();
 
     it('unassertAst ' + fixtureName, function () {
-      const ast = parse(fixtureFilepath);
+      const ast = parseFixture(fixtureFilepath);
       const modifiedAst = unassertAst(ast);
-      const actual = escodegen.generate(modifiedAst);
+      const actual = generate(modifiedAst);
       assert.equal(actual + '\n', expected);
     });
     it('createVisitor ' + fixtureName, function () {
-      const ast = parse(fixtureFilepath);
-      const modifiedAst = estraverse.replace(ast, createVisitor());
-      const actual = escodegen.generate(modifiedAst);
+      const ast = parseFixture(fixtureFilepath);
+      const modifiedAst = replace(ast, createVisitor());
+      const actual = generate(modifiedAst);
       assert.equal(actual + '\n', expected);
     });
   }
@@ -46,20 +46,20 @@ describe('default behavior (with default options)', function () {
 
 describe('with customized options', function () {
   function testWithCustomization (fixtureName, options) {
-    const fixtureFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
-    const expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected.js');
-    const expected = fs.readFileSync(expectedFilepath).toString();
+    const fixtureFilepath = resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
+    const expectedFilepath = resolve(__dirname, 'fixtures', fixtureName, 'expected.js');
+    const expected = readFileSync(expectedFilepath).toString();
 
     it('unassertAst ' + fixtureName, function () {
-      const ast = parse(fixtureFilepath);
+      const ast = parseFixture(fixtureFilepath);
       const modifiedAst = unassertAst(ast, options);
-      const actual = escodegen.generate(modifiedAst);
+      const actual = generate(modifiedAst);
       assert.equal(actual + '\n', expected);
     });
     it('createVisitor ' + fixtureName, function () {
-      const ast = parse(fixtureFilepath);
-      const modifiedAst = estraverse.replace(ast, createVisitor(options));
-      const actual = escodegen.generate(modifiedAst);
+      const ast = parseFixture(fixtureFilepath);
+      const modifiedAst = replace(ast, createVisitor(options));
+      const actual = generate(modifiedAst);
       assert.equal(actual + '\n', expected);
     });
   }

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -6,8 +6,7 @@ import { parse } from 'acorn';
 import { generate } from 'escodegen';
 import { replace } from 'estraverse';
 import { fileURLToPath } from 'url';
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function parseFixture (filepath) {
   return parse(readFileSync(filepath), { sourceType: 'module', ecmaVersion: '2022' });


### PR DESCRIPTION
Migrate codebase to ESM and provide CJS/ESM dual package
https://nodejs.org/api/packages.html#dual-commonjses-module-packages