### PR TITLE
feat: Support strict assertion mode newly exposed as 'node:assert/strict'

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ For example,
 {
   modules: [
     'assert',
-    'node:assert'
+    'assert/strict',
+    'node:assert',
+    'node:assert/strict'
   ]
 ```
 
@@ -170,12 +172,18 @@ will remove assert variable declarations such as,
 
 * `const assert = require("assert")`
 * `const assert = require("node:assert")`
+* `const assert = require("assert/strict")`
+* `const assert = require("node:assert/strict")`
 * `const assert = require("assert").strict`
 * `const assert = require("node:assert").strict`
 * `import assert from "assert"`
+* `import assert from "assert/strict"`
 * `import assert from "node:assert"`
+* `import assert from "node:assert/strict"`
 * `import * as assert from "assert"`
 * `import * as assert from "node:assert"`
+* `import * as assert from "assert/strict"`
+* `import * as assert from "node:assert/strict"`
 * `import {strict as assert} from "assert"`
 * `import {strict as assert} from "node:assert"`
 
@@ -183,6 +191,8 @@ and assignments.
 
 * `assert = require("assert")`
 * `assert = require("node:assert")`
+* `assert = require("assert/strict")`
+* `assert = require("node:assert/strict")`
 * `assert = require("assert").strict`
 * `assert = require("node:assert").strict`
 
@@ -207,7 +217,9 @@ Returns default options object for `unassertAst` and `createVisitor` function. I
   ],
   modules: [
     'assert',
-    'node:assert'
+    'assert/strict',
+    'node:assert',
+    'node:assert/strict'
   ]
 }
 ```

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -18,7 +18,9 @@ function defaultOptions () {
     ],
     modules: [
       'assert',
-      'node:assert'
+      'assert/strict',
+      'node:assert',
+      'node:assert/strict'
     ]
   };
 }

--- a/test/fixtures/assignment/fixture.js
+++ b/test/fixtures/assignment/fixture.js
@@ -1,5 +1,5 @@
 var assert;
-assert = require('assert');
+assert = require('assert/strict');
 function add (a, b) {
     console.assert(typeof a === 'number');
     assert(!isNaN(a));

--- a/test/fixtures/assignment_singlevar/fixture.js
+++ b/test/fixtures/assignment_singlevar/fixture.js
@@ -1,5 +1,5 @@
 var add, assert;
-assert = require('assert');
+assert = require('assert').strict;
 add = function (a, b) {
     console.assert(typeof a === 'number');
     assert(!isNaN(a));

--- a/test/fixtures/cjs/require_assert_slash_strict.cjs
+++ b/test/fixtures/cjs/require_assert_slash_strict.cjs
@@ -1,0 +1,10 @@
+'use strict';
+
+const assert = require('assert/strict');
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/cjs/require_node_assert_slash_strict.cjs
+++ b/test/fixtures/cjs/require_node_assert_slash_strict.cjs
@@ -1,0 +1,10 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/mjs/import_default_specifier_node_protocol_slash_strict.mjs
+++ b/test/fixtures/mjs/import_default_specifier_node_protocol_slash_strict.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/mjs/import_default_specifier_slash_strict.mjs
+++ b/test/fixtures/mjs/import_default_specifier_slash_strict.mjs
@@ -1,0 +1,8 @@
+import assert from 'assert/strict';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/mjs/import_namespace_specifier_node_protocol_slash_strict.mjs
+++ b/test/fixtures/mjs/import_namespace_specifier_node_protocol_slash_strict.mjs
@@ -1,0 +1,8 @@
+import * as assert from 'node:assert/strict';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/mjs/import_namespace_specifier_slash_strict.mjs
+++ b/test/fixtures/mjs/import_namespace_specifier_slash_strict.mjs
@@ -1,0 +1,8 @@
+import * as assert from 'assert/strict';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -37,8 +37,12 @@ describe('ESM', function () {
   }
   testESM('import_default_specifier');
   testESM('import_default_specifier_node_protocol');
+  testESM('import_default_specifier_slash_strict');
+  testESM('import_default_specifier_node_protocol_slash_strict');
   testESM('import_namespace_specifier');
   testESM('import_namespace_specifier_node_protocol');
+  testESM('import_namespace_specifier_slash_strict');
+  testESM('import_namespace_specifier_node_protocol_slash_strict');
   testESM('import_specifier_strict');
   testESM('import_specifier_strict_node_protocol');
 });
@@ -49,8 +53,10 @@ describe('CJS', function () {
   }
   testCJS('require_assert');
   testCJS('require_assert_dot_strict');
+  testCJS('require_assert_slash_strict');
   testCJS('require_node_assert');
   testCJS('require_node_assert_dot_strict');
+  testCJS('require_node_assert_slash_strict');
 });
 
 describe('default behavior (with default options)', function () {


### PR DESCRIPTION
https://nodejs.org/api/assert.html#strict-assertion-mode

Support removal of
* `const assert = require("assert/strict")`
* `const assert = require("node:assert/strict")`
* `import assert from "assert/strict"`
* `import assert from "node:assert/strict"`
* `import * as assert from "assert/strict"`
* `import * as assert from "node:assert/strict"`
* `let assert; assert = require("assert/strict")`
* `let assert; assert = require("node:assert/strict")`
