### PR TITLE
feat: Support destructured assignment of strict property

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ will remove assert variable declarations such as,
 * `const assert = require("node:assert/strict")`
 * `const assert = require("assert").strict`
 * `const assert = require("node:assert").strict`
+* `const { strict: assert } = require("assert")`
+* `const { strict: assert } = require("node:assert")`
 * `import assert from "assert"`
 * `import assert from "assert/strict"`
 * `import assert from "node:assert"`
@@ -184,8 +186,8 @@ will remove assert variable declarations such as,
 * `import * as assert from "node:assert"`
 * `import * as assert from "assert/strict"`
 * `import * as assert from "node:assert/strict"`
-* `import {strict as assert} from "assert"`
-* `import {strict as assert} from "node:assert"`
+* `import { strict as assert } from "assert"`
+* `import { strict as assert } from "node:assert"`
 
 and assignments.
 

--- a/test/fixtures/cjs/destructuring_strict_require_assert.cjs
+++ b/test/fixtures/cjs/destructuring_strict_require_assert.cjs
@@ -1,0 +1,10 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/cjs/destructuring_strict_require_node_assert.cjs
+++ b/test/fixtures/cjs/destructuring_strict_require_node_assert.cjs
@@ -1,0 +1,10 @@
+'use strict';
+
+const { strict: assert } = require('node:assert');
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -57,6 +57,8 @@ describe('CJS', function () {
   testCJS('require_node_assert');
   testCJS('require_node_assert_dot_strict');
   testCJS('require_node_assert_slash_strict');
+  testCJS('destructuring_strict_require_assert');
+  testCJS('destructuring_strict_require_node_assert');
 });
 
 describe('default behavior (with default options)', function () {


### PR DESCRIPTION
Support removal of 

* `const { strict: assert } = require('assert');`
* `const { strict: assert } = require('node:assert');`
