### PR TITLE
fix: unassert causes SyntaxError when body of LabeledStatement is single ExpressionStatement

### DIFF
--- a/test/fixtures/non_block_statement/expected.js
+++ b/test/fixtures/non_block_statement/expected.js
@@ -8,6 +8,8 @@ function add(a, b) {
     } else if (typeof b === 'number') {
     } else {
     }
+    ensure: {
+    }
     for (const i of [
             a,
             b

--- a/test/fixtures/non_block_statement/fixture.js
+++ b/test/fixtures/non_block_statement/fixture.js
@@ -15,6 +15,9 @@ function add (a, b) {
     else
         assert(false);
 
+    ensure:
+        assert(0 < a);
+
     for (const i of [a, b])
       assert (0 < i);
 


### PR DESCRIPTION
Body of LabeledStatement or WithStatement can be single ExpressionStatement and causes SyntaxError when removed.
So instead of removing it, replace it with empty BlockStatement.