### PR TITLE
[Fix] fix "exports" for node 13.0-13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,14 @@
     "dist"
   ],
   "main": "./dist/index.cjs",
-  "exports": {
-    "import": "./src/index.mjs",
-    "require": "./dist/index.cjs"
-  },
+  "exports": [
+    {
+      "import": "./src/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.cjs"
+    },
+    "./dist/index.cjs"
+  ],
   "homepage": "https://github.com/unassert-js/unassert",
   "keywords": [
     "DbC",


### PR DESCRIPTION
 - node 13.0-13.1 only supports the string form
 - node 13.2 - 13.6 in an object only supports "default"

This commit allows these node versions to work.